### PR TITLE
Add env based API key mask

### DIFF
--- a/packages/stablestudio-plugin-stability/src/index.ts
+++ b/packages/stablestudio-plugin-stability/src/index.ts
@@ -574,6 +574,7 @@ export const createPlugin = StableStudio.createPlugin<{
             placeholder: undefined,
             password: false,
             formatter: (value: string) => value, // Keep it as-is (masked)
+            readOnly: true,
           }
         : {
             type: "string",

--- a/packages/stablestudio-plugin/src/Plugin.ts
+++ b/packages/stablestudio-plugin/src/Plugin.ts
@@ -65,6 +65,9 @@ export type PluginSettingCommon = {
 
   /** Is this setting required? If so, users will be forced to provide an input */
   required?: boolean;
+
+  /** If true the setting is displayed as read-only text */
+  readOnly?: boolean;
 };
 
 /** `PluginSetting` allows for `string`, `number`, and `boolean` input types   */

--- a/packages/stablestudio-ui/src/Settings/Setting.tsx
+++ b/packages/stablestudio-ui/src/Settings/Setting.tsx
@@ -46,13 +46,17 @@ export function Setting({
         />
       )}
       {setting.type === "string" && !setting.options && (
-        <Theme.Input
-          placeholder={setting.placeholder}
-          // TODO: Fix this
-          value={value}
-          onChange={onSet}
-          type={setting.password ? "password" : "text"}
-        />
+        setting.readOnly ? (
+          <Theme.Label className="mx-0">{value}</Theme.Label>
+        ) : (
+          <Theme.Input
+            placeholder={setting.placeholder}
+            // TODO: Fix this
+            value={value}
+            onChange={onSet}
+            type={setting.password ? "password" : "text"}
+          />
+        )
       )}
       {setting.type === "number" &&
         (setting.variant === "input" || !setting.variant) && (


### PR DESCRIPTION
## Summary
- support readonly plugin settings
- show masked API key text when `VITE_STABILITY_API_KEY` is set
- surface `readOnly` flag in plugin UI

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6878bbcb5a9483249bec48a09ed4035c